### PR TITLE
Elide :anonymous defs from completions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,5 @@ branches:
   only:
     - master
 jdk:
-  - openjdk6
   - openjdk7
   - oraclejdk7

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies []
-  :profiles {:dev {:dependencies [[org.clojure/clojure "1.5.1"]
-                                  [org.clojure/clojurescript "0.0-2202"]
-                                  [org.clojure/core.async "0.1.303.0-886421-alpha"]
+  :profiles {:dev {:dependencies [[org.clojure/clojure "1.6.0"]
+                                  [org.clojure/clojurescript "0.0-2760"]
+                                  [org.clojure/core.async "0.1.346.0-17112a-alpha"]
                                   [om "0.6.2"]]}})

--- a/src/cljs_tooling/util/analysis.clj
+++ b/src/cljs_tooling/util/analysis.clj
@@ -76,11 +76,15 @@
   [var]
   ((complement :private) (val var)))
 
+(defn- named?
+  [var]
+  ((complement :anonymous) (val var)))
+
 (defn public-vars
   "Returns a list of the public vars declared in the ns."
   [env ns]
   (let [vars (:defs (find-ns env ns))]
-    (into {} (filter public? vars))))
+    (into {} (filter (every-pred public? named?) vars))))
 
 (defn- macro?
   [var]
@@ -107,8 +111,11 @@
   "Vars visible to the ns"
   ([env ns] (ns-vars env ns false))
   ([env ns include-core?]
-     (merge (:defs (find-ns env ns))
-            (if include-core? (core-vars env ns)))))
+   (merge (->> (find-ns env ns)
+               :defs
+               (filter named?)
+               (into {}))
+          (if include-core? (core-vars env ns)))))
 
 (defn core-macros
   "Returns a list of cljs.core macros visible to the ns."

--- a/test/cljs_tooling/test_complete.clj
+++ b/test/cljs_tooling/test_complete.clj
@@ -77,7 +77,14 @@
 
   (testing "Local var"
     (is (= '("sliding-buffer")
-           (completions "sli" "cljs.core.async")))))
+           (completions "sli" "cljs.core.async"))))
+
+  (testing "Private vars"
+    (is (= '()
+           (completions "cljs.core.async/fhno")
+           (completions "cljs.core.async/fhno" "om.core")))
+    (is (= '("fhnop")
+           (completions "fhno" "cljs.core.async"))))
 
   (testing "Anonymous vars are not returned"
     (is (= '()

--- a/test/cljs_tooling/test_complete.clj
+++ b/test/cljs_tooling/test_complete.clj
@@ -41,10 +41,11 @@
 
   (testing "Macro namespace alias"
     (is (= '()
-           (completions "ioc")
-           (completions "ioc" "cljs.core.async")))
+           (completions "ioc")))
+    (is (= '("ioc")
+           (completions "io" "cljs.core.async.impl.ioc-helpers")))
     (is (= '("ioc" "ioc-alts!")
-           (completions "io" "cljs.core.async.impl.ioc-helpers")))))
+           (completions "ioc" "cljs.core.async")))))
 
 (deftest var-completions
   (testing "cljs.core var"

--- a/test/cljs_tooling/test_complete.clj
+++ b/test/cljs_tooling/test_complete.clj
@@ -79,6 +79,11 @@
     (is (= '("sliding-buffer")
            (completions "sli" "cljs.core.async")))))
 
+  (testing "Anonymous vars are not returned"
+    (is (= '()
+           (completions "cljs.core.async/->t")
+           (completions "->t" "cljs.core.async")))))
+
 (deftest macro-completions
   (testing "cljs.core macro"
     (is (= '("cond" "cond->" "cond->>" "condp")

--- a/test/cljs_tooling/test_info.clj
+++ b/test/cljs_tooling/test_info.clj
@@ -53,7 +53,7 @@
     (is (= (select-keys res [:ns :column :line :name :arglists :doc])
            '{:ns clojure.string
              :column 1
-             :line 132
+             :line 147
              :name trim
              :arglists ([s])
              :doc "Removes whitespace from both ends of string."})))
@@ -78,7 +78,7 @@
 
   ;; test macro ns alias
   (is (= (info 'ioc)
-         (info 'ioc 'cljs.core.async)
+         (info 'ioc 'om.core)
          nil))
   (is (= (info 'ioc 'cljs.core.async.impl.ioc-helpers)
          '{:author nil
@@ -97,7 +97,7 @@
            :doc "Evaluates the exprs in a lexical context in which the symbols in\n  the binding-forms are bound to their respective init-exprs or parts\n  therein. Acts as a recur target."
            :file "cljs/core.clj"
            :column 1
-           :line 154
+           :line 159
            :name loop
            :arglists ([bindings & body])}))
 


### PR DESCRIPTION
`reify` creates anonymous type symbols, which are included in completion results:

<img src="https://www.dropbox.com/s/uvqswq2xqz36zk3/Screenshot%202015-02-05%2018.09.45.png?raw=1" width="250" />

Since [this commit](https://github.com/clojure/clojurescript/commit/2fa939bb3bb8c90ac0567db2b5dd2ad87dc1f3ae#diff-b64165608bed8fb21a132890b4e2fca2R637) these now have `:anonymous` metadata.

Example metadata and the actual source location:

```edn
{:protocol-inline nil,
 :protocols #{cljs.core/IMeta cljs.core/IDeref cljs.core/IWithMeta},
 :name cljs.core.async.impl.channels/->t27832,
 :variadic false,
 :file
 "file:/Users/griffithsm/.m2/repository/org/clojure/core.async/0.1.346.0-17112a-alpha/core.async-0.1.346.0-17112a-alpha.jar!/cljs/core/async/impl/channels.cljs",
 :method-params ([val box meta27833]),
 :protocol-impl nil,
 :arglists-meta (nil nil),
 :anonymous true,
 :column 3,
 :factory :positional,
 :methods
 ({:tag cljs.core.async.impl.channels/t27832,
   :variadic false,
   :max-fixed-arity 3}),
 :line 17,
 :max-fixed-arity 3,
 :fn-var true,
 :arglists '([val box meta27833]),
 :skip-protocol-flag
 #{cljs.core/IMeta cljs.core/IDeref cljs.core/IWithMeta},
 :test true}
```

```clojure
...
(defn box [val]
  (reify cljs.core/IDeref
    (-deref [_] val)))
...
```

With the patch applied, all better:

<img src="https://www.dropbox.com/s/5l7hr9a63kep8r0/Screenshot%202015-02-05%2018.25.14.png?raw=1" width="250" />
