### PR TITLE
Completion metadata

### DIFF
--- a/src/cljs_tooling/complete.clj
+++ b/src/cljs_tooling/complete.clj
@@ -56,10 +56,10 @@
   "Return a sequence of matching completions given current namespace and a prefix string"
   ([env prefix] (completions env prefix nil))
   ([env prefix context-ns]
-     (->> (potential-completions env (u/as-sym prefix) (u/as-sym context-ns))
-          distinct
-          (map str)
-          (filter #(.startsWith % prefix))
-          sort)))
+   (->> (potential-completions env (u/as-sym prefix) (u/as-sym context-ns))
+        distinct
+        (map str)
+        (filter #(.startsWith % prefix))
+        sort)))
 
 

--- a/src/cljs_tooling/complete.clj
+++ b/src/cljs_tooling/complete.clj
@@ -3,23 +3,128 @@
   (:require [cljs-tooling.util.analysis :as a]
             [cljs-tooling.util.misc :as u]))
 
+(defn- candidate-data
+  "Returns a map of candidate data for the given arguments."
+  [candidate ns type]
+  {:candidate (name candidate)
+   :ns (symbol ns)
+   :type type})
+
+(defn- var->type
+  "Returns the candidate type corresponding to the given metadata map."
+  [var]
+  (condp #(get %2 %1) var
+    :protocol :protocol-function
+    :fn-var :function
+    :record :record
+    :protocols :type
+    :protocol-symbol :protocol
+    :var))
+
 (def special-forms
   '#{& . case* catch def defrecord* deftype* do finally fn* if js* let*
      letfn* loop* new ns quote recur set! throw try})
 
-(defn prefix-completions
-  [prefix completions]
-  (map #(symbol (str prefix "/" %)) completions))
+(def special-form-candidates
+  "Candidate data for all special forms."
+  (for [form special-forms]
+    (candidate-data form 'cljs.core :special-form)))
 
-(defn ns-completions
-  "Returns a list of public vars in the given namespace."
-  ([env ns] (keys (a/public-vars env ns)))
-  ([env ns prefix] (prefix-completions prefix (ns-completions env ns))))
+(defn all-ns-candidates
+  "Returns candidate data for all namespaces in the environment."
+  [env]
+  (for [[ns _] (a/all-ns env)]
+    (candidate-data ns ns :namespace)))
 
-(defn macro-ns-completions
-  "Returns a list of macro names in the given namespace."
-  ([ns] (keys (a/public-macros ns)))
-  ([ns prefix] (prefix-completions prefix (macro-ns-completions ns))))
+(defn ns-candidates
+  "Returns candidate data for all referred namespaces (and their aliases) in context-ns."
+  [env context-ns]
+  (for [[alias ns] (a/ns-aliases env context-ns)]
+    (candidate-data alias ns :namespace)))
+
+(defn macro-ns-candidates
+  "Returns candidate data for all referred macro namespaces (and their aliases) in
+  context-ns."
+  [env context-ns]
+  (for [[alias ns] (a/macro-ns-aliases env context-ns)]
+    (candidate-data alias ns :namespace)))
+
+(defn referred-var-candidates
+  "Returns candidate data for all referred vars in context-ns."
+  [env context-ns]
+  (for [[refer qualified-name] (a/referred-vars env context-ns)
+        :let [ns (namespace qualified-name)
+              type (var->type (a/find-var env qualified-name))]]
+    (candidate-data refer ns type)))
+
+(defn referred-macro-candidates
+  "Returns candidate data for all referred macros in context-ns."
+  [env context-ns]
+  (for [[refer qualified-name] (a/referred-macros env context-ns)
+        :let [ns (namespace qualified-name)]]
+    (candidate-data refer ns :macro)))
+
+(defn- var-candidates
+  [vars]
+  (for [[name meta] vars
+        :let [qualified-name (:name meta)
+              ns (namespace qualified-name)
+              type (var->type meta)]]
+    (candidate-data name ns type)))
+
+(defn ns-var-candidates
+  "Returns candidate data for all vars defined in ns."
+  [env ns]
+  (var-candidates (a/ns-vars env ns)))
+
+(defn core-var-candidates
+  "Returns candidate data for all cljs.core vars visible in context-ns."
+  [env context-ns]
+  (var-candidates (a/core-vars env context-ns)))
+
+(defn macro-candidates
+  [macros]
+  (for [[name var] macros
+        :let [var-meta (meta var)
+              ns (ns-name (:ns var-meta))]]
+    (candidate-data name ns :macro)))
+
+(defn core-macro-candidates
+  [env ns]
+  "Returns candidate data for all cljs.core macros visible in ns."
+  (macro-candidates (a/core-macros env ns)))
+
+(defn import-candidates
+  "Returns candidate data for all imports in context-ns."
+  [env context-ns]
+  (flatten
+   (for [[import qualified-name] (a/imports env context-ns)]
+     [(candidate-data import qualified-name :import)
+      (candidate-data qualified-name qualified-name :import)])))
+
+(defn unscoped-candidates
+  "Returns all non-namespace-qualified potential candidates in context-ns."
+  [env context-ns]
+  (concat special-form-candidates
+          (all-ns-candidates env)
+          (ns-candidates env context-ns)
+          (macro-ns-candidates env context-ns)
+          (referred-var-candidates env context-ns)
+          (referred-macro-candidates env context-ns)
+          (ns-var-candidates env context-ns)
+          (core-var-candidates env context-ns)
+          (core-macro-candidates env context-ns)
+          (import-candidates env context-ns)))
+
+(defn- prefix-candidate
+  [prefix candidate-data]
+  (let [candidate (:candidate candidate-data)
+        prefixed-candidate (str prefix "/" candidate)]
+    (assoc candidate-data :candidate prefixed-candidate)))
+
+(defn- prefix-candidates
+  [prefix candidates]
+  (map #(prefix-candidate prefix %) candidates))
 
 (defn- scope->ns
   [env scope context-ns]
@@ -33,41 +138,58 @@
     scope
     (a/to-macro-ns env scope context-ns)))
 
-(defn scoped-completions
+(defn ns-public-var-candidates
+  "Returns candidate data for all public vars defined in ns."
+  [env ns]
+  (var-candidates (a/public-vars env ns)))
+
+(defn ns-macro-candidates
+  "Returns candidate data for all macros defined in ns."
+  [env ns]
+  (macro-candidates (a/public-macros ns)))
+
+(defn scoped-candidates
+  "Returns all candidates for the namespace of sym. Sym must be
+  namespace-qualified. Macro candidates are included if the namespace has its
+  macros required in context-ns."
   [env sym context-ns]
   (let [scope (symbol (namespace sym))
-        ns (scope->ns scope)
-        macro-ns (scope->macro-ns scope)]
-    (concat (ns-completions env ns scope)
-            (macro-ns-completions macro-ns scope))))
+        ns (scope->ns env scope context-ns)
+        macro-ns (scope->macro-ns env scope context-ns)]
+    (mapcat #(prefix-candidates scope %)
+            [(ns-public-var-candidates env ns)
+             (ns-macro-candidates env macro-ns)])))
 
-(defn unscoped-completions
-  [env context-ns]
-  (concat special-forms
-          (keys (a/all-ns env))
-          (keys (a/ns-aliases env context-ns))
-          (keys (a/macro-ns-aliases env context-ns))
-          (keys (a/referred-vars env context-ns))
-          (keys (a/referred-macros env context-ns))
-          (keys (a/ns-vars env context-ns true))
-          (keys (a/core-macros env context-ns))
-          (keys (a/imports env context-ns))
-          (vals (a/imports env context-ns))))
-
-(defn potential-completions
+(defn potential-candidates
+  "Returns all candidates for sym. If sym is namespace-qualified, the candidates
+  for that namespace will be returned (including macros if the namespace has its
+  macros required in context-ns). Otherwise, all non-namespace-qualified
+  candidates for context-ns will be returned."
   [env sym context-ns]
   (if (namespace sym)
-    (scoped-completions env sym context-ns)
-    (unscoped-completions env context-ns)))
+    (scoped-candidates env sym context-ns)
+    (unscoped-candidates env context-ns)))
+
+(defn- distinct-candidates
+  "Filters candidates to have only one entry for each value of :candidate. If
+  multiple such entries do exist, the first occurrence is used."
+  [candidates]
+  (map first (vals (group-by :candidate candidates))))
+
+(defn- candidate-match?
+  [candidate prefix]
+  (.startsWith ^String (:candidate candidate) (str prefix)))
 
 (defn completions
-  "Return a sequence of matching completions given current namespace and a prefix string"
+  "Returns a sequence of candidate data for completions matching the given
+  prefix string and (optionally) the current namespace."
   ([env prefix] (completions env prefix nil))
   ([env prefix context-ns]
-   (->> (potential-completions env (u/as-sym prefix) (u/as-sym context-ns))
-        distinct
-        (map str)
-        (filter #(.startsWith % prefix))
-        sort)))
+   (let [prefix (u/as-sym prefix)
+         context-ns (u/as-sym context-ns)]
+     (->> (potential-candidates env prefix context-ns)
+          distinct-candidates
+          (filter #(candidate-match? % prefix))
+          (sort-by :candidate)))))
 
 

--- a/src/cljs_tooling/complete.clj
+++ b/src/cljs_tooling/complete.clj
@@ -21,15 +21,23 @@
   ([ns] (keys (a/public-macros ns)))
   ([ns prefix] (prefix-completions prefix (macro-ns-completions ns))))
 
+(defn- scope->ns
+  [env scope context-ns]
+  (if (a/find-ns env scope)
+    scope
+    (a/to-ns env scope context-ns)))
+
+(defn- scope->macro-ns
+  [env scope context-ns]
+  (if (= scope 'cljs.core)
+    scope
+    (a/to-macro-ns env scope context-ns)))
+
 (defn scoped-completions
   [env sym context-ns]
   (let [scope (symbol (namespace sym))
-        ns (if (a/find-ns env scope)
-             scope
-             (a/to-ns env scope context-ns))
-        macro-ns (if (= scope 'cljs.core)
-                   scope
-                   (a/to-macro-ns env scope context-ns))]
+        ns (scope->ns scope)
+        macro-ns (scope->macro-ns scope)]
     (concat (ns-completions env ns scope)
             (macro-ns-completions macro-ns scope))))
 

--- a/src/cljs_tooling/complete.clj
+++ b/src/cljs_tooling/complete.clj
@@ -3,14 +3,6 @@
   (:require [cljs-tooling.util.analysis :as a]
             [cljs-tooling.util.misc :as u]))
 
-;;; TODO
-(defn ns-classes
-  "Returns a list of potential class name completions for a given namespace"
-  [env ns]
-
-  ;;(map name (keys (ns-imports ns)))
-  )
-
 (def special-forms
   '#{& . case* catch def defrecord* deftype* do finally fn* if js* let*
      letfn* loop* new ns quote recur set! throw try})
@@ -52,8 +44,7 @@
           (keys (a/ns-vars env context-ns true))
           (keys (a/core-macros env context-ns))
           (keys (a/imports env context-ns))
-          (vals (a/imports env context-ns))
-          (ns-classes env context-ns)))
+          (vals (a/imports env context-ns))))
 
 (defn potential-completions
   [env sym context-ns]

--- a/src/cljs_tooling/info.clj
+++ b/src/cljs_tooling/info.clj
@@ -88,7 +88,10 @@
      [macro (get (a/referred-macros env context-ns) sym)] (format-macro (-> macro find-var meta))
 
      ;; var in ns
-     [context-var (get (a/ns-vars env context-ns true) sym)] (format-var context-ns context-var)
+     [context-var (get (a/ns-vars env context-ns) sym)] (format-var context-ns context-var)
+
+     ;; var in cljs.core
+     [var (get (a/core-vars env context-ns) sym)] (format-var context-ns var)
 
      ;; macro in cljs.core
      [macro (get (a/public-macros 'cljs.core) sym)] (format-macro (meta macro))

--- a/src/cljs_tooling/util/analysis.clj
+++ b/src/cljs_tooling/util/analysis.clj
@@ -22,10 +22,20 @@
 
 ;; Code adapted from clojure-complete (http://github.com/ninjudd/clojure-complete)
 
+(defn imports
+  "Returns a map of [import-name] to [ns-qualified-import-name] for all imports
+  in the given namespace."
+  [env ns]
+  (:imports (find-ns env ns)))
+
 (defn ns-aliases
   "Returns a map of [ns-name-or-alias] to [ns-name] for the given namespace."
   [env ns]
-  (:requires (find-ns env ns)))
+  (let [imports (imports env ns)]
+    (->> (find-ns env ns)
+         :requires
+         (filter #(not (contains? imports (key %))))
+         (into {}))))
 
 (defn macro-ns-aliases
   "Returns a map of [macro-ns-name-or-alias] to [macro-ns-name] for the given namespace."
@@ -51,12 +61,6 @@
   (->> (find-ns env ns)
        :use-macros
        expand-refer-map))
-
-(defn imports
-  "Returns a map of [import-name] to [ns-qualified-import-name] for all imports
-  in the given namespace."
-  [env ns]
-  (:imports (find-ns env ns)))
 
 (defn to-ns
   "If sym is an alias to, or the name of, a namespace referred to in ns, returns

--- a/src/cljs_tooling/util/analysis.clj
+++ b/src/cljs_tooling/util/analysis.clj
@@ -97,7 +97,7 @@
 (defn public-macros
   "Returns a list of the public macros declared in the ns."
   [ns]
-  (if (and ns (clojure.core/find-ns ns))
+  (when (and ns (clojure.core/find-ns ns))
     (->> (ns-publics ns)
          (filter macro?)
          (into {}))))

--- a/src/cljs_tooling/util/analysis.clj
+++ b/src/cljs_tooling/util/analysis.clj
@@ -82,17 +82,27 @@
   [var]
   ((complement :anonymous) (val var)))
 
-(defn public-vars
-  "Returns a list of the public vars declared in the ns."
-  [env ns]
-  (let [vars (:defs (find-ns env ns))]
-    (into {} (filter (every-pred public? named?) vars))))
-
 (defn- macro?
   [var]
   (-> (val var)
       meta
       :macro))
+
+(defn ns-vars
+  "Returns a list of the vars declared in the ns."
+  [env ns]
+  (->> (find-ns env ns)
+       :defs
+       (filter named?)
+       (into {})))
+
+(defn public-vars
+  "Returns a list of the public vars declared in the ns."
+  [env ns]
+  (->> (find-ns env ns)
+       :defs
+       (filter (every-pred named? public?))
+       (into {})))
 
 (defn public-macros
   "Returns a list of the public macros declared in the ns."
@@ -108,16 +118,6 @@
   (let [vars (public-vars env 'cljs.core)
         excludes (:excludes (find-ns env ns))]
     (apply dissoc vars excludes)))
-
-(defn ns-vars
-  "Returns a list of vars visible to the ns."
-  ([env ns] (ns-vars env ns false))
-  ([env ns include-core?]
-   (merge (->> (find-ns env ns)
-               :defs
-               (filter named?)
-               (into {}))
-          (if include-core? (core-vars env ns)))))
 
 (defn core-macros
   "Returns a list of cljs.core macros visible to the ns."

--- a/src/cljs_tooling/util/analysis.clj
+++ b/src/cljs_tooling/util/analysis.clj
@@ -108,7 +108,7 @@
     (apply dissoc vars excludes)))
 
 (defn ns-vars
-  "Vars visible to the ns"
+  "Returns a list of vars visible to the ns."
   ([env ns] (ns-vars env ns false))
   ([env ns include-core?]
    (merge (->> (find-ns env ns)

--- a/src/cljs_tooling/util/analysis.clj
+++ b/src/cljs_tooling/util/analysis.clj
@@ -2,7 +2,6 @@
   (:require [cljs-tooling.util.misc :as u])
   (:refer-clojure :exclude [find-ns find-var all-ns ns-aliases]))
 
-
 (def NSES :cljs.analyzer/namespaces)
 
 (defn all-ns
@@ -22,7 +21,6 @@
     (get (:defs ns) (-> sym name symbol))))
 
 ;; Code adapted from clojure-complete (http://github.com/ninjudd/clojure-complete)
-
 
 (defn ns-aliases
   "Returns a map of [ns-name-or-alias] to [ns-name] for the given namespace."

--- a/test-resources/test_ns.cljs
+++ b/test-resources/test_ns.cljs
@@ -3,3 +3,5 @@
   (:require [cljs.core.async :refer [sliding-buffer]]
             [clojure.string]
             [om.core]))
+
+(defrecord TestRecord [a b c])

--- a/test/cljs_tooling/test_complete.clj
+++ b/test/cljs_tooling/test_complete.clj
@@ -17,9 +17,48 @@
   [& args]
   (apply cc/completions test-env/*env* args))
 
+(deftest sanity
+  (testing "Empty string args equivalent"
+    (is (= (completions "")
+           (completions "" ""))))
+
+  (testing "Nothing returned for non-existent prefix"
+    (is (= '()
+           (completions "abcdefghijk")
+           (completions "abcdefghijk" "cljs-tooling.test-ns"))))
+
+  (testing "cljs.core candidates returned for new namespaces"
+    (is (= (completions "")
+           (completions "" "abcdefghijk"))))
+
+  (let [all-candidates (completions "" "cljs-tooling.test-ns")]
+    (testing "All candidates have a string for :candidate"
+      (is (every? (comp string? :candidate) all-candidates)))
+
+    (testing "All candidates have a symbol for :ns"
+      (is (every? (comp symbol? :ns) all-candidates)))
+
+    (testing "All candidates have a valid :type"
+      (let [valid-types #{:function
+                          :import
+                          :macro
+                          :namespace
+                          :protocol
+                          :protocol-function
+                          :record
+                          :special-form
+                          :type
+                          :var}]
+        (is (every? (comp valid-types :type) all-candidates))))))
+
+(deftest special-form-completions
+  (testing "Special form"
+    (is (= '({:candidate "throw" :ns cljs.core :type :special-form})
+           (completions "thr")))))
+
 (deftest namespace-completions
   (testing "Namespace"
-    (is (= '("cljs.core.async.impl.timers")
+    (is (= '({:candidate "cljs.core.async.impl.timers" :ns cljs.core.async.impl.timers :type :namespace})
            (completions "cljs.core.async.impl.t")
            (completions "cljs.core.async.impl.t" "om.core")
            (completions "cljs.core.async.impl.t" "cljs.core.async"))))
@@ -28,7 +67,7 @@
     (is (= '()
            (completions "timers")
            (completions "timers" "om.core")))
-    (is (= '("timers")
+    (is (= '({:candidate "timers" :ns cljs.core.async.impl.timers :type :namespace})
            (completions "timers" "cljs.core.async")))))
 
 (deftest macro-namespace-completions
@@ -36,100 +75,133 @@
     (is (= '()
            (completions "cljs.core.async.macros")
            (completions "cljs.core.async.macros" "om.core")))
-    (is (= '("cljs.core.async.macros")
+    (is (= '({:candidate "cljs.core.async.macros" :ns cljs.core.async.macros :type :namespace})
            (completions "cljs.core.async.macros" "cljs.core.async"))))
 
   (testing "Macro namespace alias"
     (is (= '()
            (completions "ioc")))
-    (is (= '("ioc")
+    (is (= '({:candidate "ioc" :ns cljs.core.async.impl.ioc-macros :type :namespace})
            (completions "io" "cljs.core.async.impl.ioc-helpers")))
-    (is (= '("ioc" "ioc-alts!")
+    (is (= '({:candidate "ioc" :ns cljs.core.async.impl.ioc-macros :type :namespace}
+             {:candidate "ioc-alts!" :ns cljs.core.async :type :function})
            (completions "ioc" "cljs.core.async")))))
 
-(deftest var-completions
-  (testing "cljs.core var"
-    (is (= '("unchecked-add" "unchecked-add-int")
+(deftest fn-completions
+  (testing "cljs.core fn"
+    (is (= '({:candidate "unchecked-add" :ns cljs.core :type :function}
+             {:candidate "unchecked-add-int" :ns cljs.core :type :function})
            (completions "unchecked-a")
            (completions "unchecked-a" "cljs.core.async")))
-    (is (= '("cljs.core/unchecked-add" "cljs.core/unchecked-add-int")
+    (is (= '({:candidate "cljs.core/unchecked-add" :ns cljs.core :type :function}
+             {:candidate "cljs.core/unchecked-add-int" :ns cljs.core :type :function})
            (completions "cljs.core/unchecked-a")
            (completions "cljs.core/unchecked-a" "cljs.core.async"))))
 
-  (testing "Excluded cljs.core var"
+  (testing "Excluded cljs.core fn"
     (is (= '()
            (completions "unchecked-b" "cljs-tooling.test-ns")))
-    (is (= '("cljs.core/unchecked-byte")
+    (is (= '({:candidate "cljs.core/unchecked-byte" :ns cljs.core :type :function})
            (completions "cljs.core/unchecked-b" "cljs-tooling.test-ns"))))
 
-  (testing "Namespace-qualified var"
-    (is (= '("cljs.core.async/sliding-buffer")
+  (testing "Namespace-qualified fn"
+    (is (= '({:candidate "cljs.core.async/sliding-buffer" :ns cljs.core.async :type :function})
            (completions "cljs.core.async/sli")
            (completions "cljs.core.async/sli" "om.core")
            (completions "cljs.core.async/sli" "cljs.core.async"))))
 
-  (testing "Referred var"
+  (testing "Referred fn"
     (is (= '()
            (completions "sli")
            (completions "sli" "om.core")))
-    (is (= '("sliding-buffer")
+    (is (= '({:candidate "sliding-buffer" :ns cljs.core.async :type :function})
            (completions "sli" "cljs-tooling.test-ns"))))
 
-  (testing "Local var"
-    (is (= '("sliding-buffer")
+  (testing "Local fn"
+    (is (= '({:candidate "sliding-buffer" :ns cljs.core.async :type :function})
            (completions "sli" "cljs.core.async"))))
 
-  (testing "Private vars"
+  (testing "Private fn"
     (is (= '()
            (completions "cljs.core.async/fhno")
            (completions "cljs.core.async/fhno" "om.core")))
-    (is (= '("fhnop")
+    (is (= '({:candidate "fhnop" :ns cljs.core.async :type :var})
            (completions "fhno" "cljs.core.async"))))
 
-  (testing "Anonymous vars are not returned"
+  (testing "Anonymous fn"
     (is (= '()
            (completions "cljs.core.async/->t")
-           (completions "->t" "cljs.core.async")))))
+           (completions "->t" "cljs.core.async"))))
+
+  (testing "Fn shadowing macro with same name"
+    (is (= '({:candidate "identical?" :ns cljs.core :type :function})
+           (completions "identical?")))))
 
 (deftest macro-completions
   (testing "cljs.core macro"
-    (is (= '("cond" "cond->" "cond->>" "condp")
-           (completions "cond")
-           (completions "cond" "om.core")))
-    (is (= '("cljs.core/cond" "cljs.core/cond->" "cljs.core/cond->>" "cljs.core/condp")
-           (completions "cljs.core/cond")
-           (completions "cljs.core/cond" "om.core"))))
+    (is (= '({:candidate "cond->" :ns cljs.core :type :macro}
+             {:candidate "cond->>" :ns cljs.core :type :macro})
+           (completions "cond-")
+           (completions "cond-" "om.core")))
+    (is (= '({:candidate "cljs.core/cond->" :ns cljs.core :type :macro}
+             {:candidate "cljs.core/cond->>" :ns cljs.core :type :macro})
+           (completions "cljs.core/cond-")
+           (completions "cljs.core/cond-" "om.core"))))
 
   (testing "Excluded cljs.core macro"
     (is (= '()
            (completions "whil" "cljs-tooling.test-ns")))
-    (is (= '("cljs.core/while")
+    (is (= '({:candidate "cljs.core/while" :ns cljs.core :type :macro})
            (completions "cljs.core/whil" "cljs-tooling.test-ns"))))
 
   (testing "Namespace-qualified macro"
     (is (= '()
            (completions "cljs.core.async.macros/go")
            (completions "cljs.core.async.macros/go" "om.core")))
-    (is (= '("cljs.core.async.macros/go" "cljs.core.async.macros/go-loop")
+    (is (= '({:candidate "cljs.core.async.macros/go" :ns cljs.core.async.macros :type :macro}
+             {:candidate "cljs.core.async.macros/go-loop" :ns cljs.core.async.macros :type :macro})
            (completions "cljs.core.async.macros/go" "cljs.core.async"))))
 
   (testing "Referred macro"
     (is (= '()
            (completions "go-")
            (completions "go-" "om.core")))
-    (is (= '("go-loop")
-           (completions "go-" "cljs.core.async"))))
+    (is (= '({:candidate "go-loop" :ns cljs.core.async.macros :type :macro})
+           (completions "go-" "cljs.core.async")))))
 
+(deftest import-completions
   (testing "Import"
     (is (= '()
            (completions "IdGen")
            (completions "IdGen" "cljs.core.async")))
-    (is (= '("IdGenerator")
+    (is (= '({:candidate "IdGenerator" :ns goog.ui.IdGenerator :type :import})
            (completions "IdGen" "om.core"))))
 
   (testing "Namespace-qualified import"
     (is (= '()
            (completions "goog.ui.IdGen")
            (completions "goog.ui.IdGen" "cljs.core.async")))
-    (is (= '("goog.ui.IdGenerator")
+    (is (= '({:candidate "goog.ui.IdGenerator" :ns goog.ui.IdGenerator :type :import})
            (completions "goog.ui.IdGen" "om.core")))))
+
+(deftest protocol-completions
+  (testing "Protocol"
+    (is (= '({:candidate "IIndexed" :ns cljs.core :type :protocol}
+             {:candidate "IIterable" :ns cljs.core :type :protocol})
+           (completions "II"))))
+
+  (testing "Protocol fn"
+    (is (= '({:candidate "-with-meta" :ns cljs.core :type :protocol-function}
+             {:candidate "-write" :ns cljs.core :type :protocol-function})
+           (completions "-w")))))
+
+(deftest record-completions
+  (testing "Record"
+    (is (= '({:candidate "TestRecord" :ns cljs-tooling.test-ns :type :record})
+           (completions "Te" "cljs-tooling.test-ns")))))
+
+(deftest type-completions
+  (testing "Type"
+    (is (= '({:candidate "ES6Iterator" :ns cljs.core :type :type}
+             {:candidate "ES6IteratorSeq" :ns cljs.core :type :type})
+           (completions "ES6I")))))


### PR DESCRIPTION
cc @bbatsov @gtrak

As discussed in #12. This is a breaking change but it would be easy to keep the old behaviour and add a new function for this.

See the tests for more examples but `completions` now returns a sequence that looks like this:

```clojure
({:candidate "*1" :ns cljs.core :type :var}
 {:candidate "-add-watch" :ns cljs.core :type :protocol-fn}
 {:candidate "aget" :ns cljs.core :type :fn}
 {:candidate "doseq" :ns cljs.core :type :macro}
 {:candidate "IdGenerator" :ns goog.ui.IdGenerator :type :import}
 {:candidate "TestRecord" :ns cljs-tooling.test-ns :type :record}
 {:candidate "TransientArrayMap" :ns cljs.core :type :type})
```

The possible values of `:type` are:

```clojure
:special-form
:ns
:fn
:protocol-fn
:record
:type
:protocol
:var
:macro
:import
```

If there are multiple candidates with the same value of `:candidate` (i.e. any of the fns in `cljs.core` that wrap macros with the same name), then only one will be used - the one that would be returned by an `info` call for the value of `:candidate` (i.e. order of preference is the same as the list above).

Not sure if we should force the client to account for all of the possible types or collapse them down a bit?