### PR TITLE
Function arglists / :extra-metadata option

### DIFF
--- a/src/cljs_tooling/complete.clj
+++ b/src/cljs_tooling/complete.clj
@@ -190,10 +190,14 @@
 
 (defn completions
   "Returns a sequence of candidate data for completions matching the given
-  prefix string and (optionally) the current namespace."
+  prefix string and options. If the third parameter is a string it's used
+  as :context-ns option.
+
+  - :context-ns - (optional) the current namespace"
   ([env prefix] (completions env prefix nil))
-  ([env prefix context-ns]
+  ([env prefix options-map]
    (let [prefix (u/as-sym prefix)
+         {:keys [context-ns] :as options-map} (if (string? options-map) {:context-ns options-map} options-map)
          context-ns (u/as-sym context-ns)]
      (->> (potential-candidates env prefix context-ns)
           distinct-candidates

--- a/test/cljs_tooling/test_complete.clj
+++ b/test/cljs_tooling/test_complete.clj
@@ -222,3 +222,14 @@
            (completions "unchecked-a")
            (completions "unchecked-a" "cljs.core.async")
            (completions "unchecked-a" {:context-ns "cljs.core.async"})))))
+
+(deftest extra-metadata
+  (testing ":arglists"
+    (is (= '({:candidate "unchecked-add" :ns cljs.core :type :function :arglists ("[]" "[x]" "[x y]" "[x y & more]")}
+             {:candidate "unchecked-add-int" :ns cljs.core :type :function :arglists ("[]" "[x]" "[x y]" "[x y & more]")})
+           (completions "unchecked-a" {:context-ns "cljs.core.async", :extra-metadata #{:arglists}}))))
+
+  (testing ":doc"
+    (is (= '({:candidate "unchecked-add" :ns cljs.core :type :function :doc "Returns the sum of nums. (+) returns 0."}
+             {:candidate "unchecked-add-int" :ns cljs.core :type :function :doc "Returns the sum of nums. (+) returns 0."})
+           (completions "unchecked-a" {:context-ns "cljs.core.async", :extra-metadata #{:doc}})))))

--- a/test/cljs_tooling/test_complete.clj
+++ b/test/cljs_tooling/test_complete.clj
@@ -214,3 +214,11 @@
     (is (= '({:candidate "ES6Iterator" :ns cljs.core :type :type}
              {:candidate "ES6IteratorSeq" :ns cljs.core :type :type})
            (completions "ES6I")))))
+
+(deftest options-map-test
+  (testing "options-map"
+    (is (= '({:candidate "unchecked-add" :ns cljs.core :type :function}
+             {:candidate "unchecked-add-int" :ns cljs.core :type :function})
+           (completions "unchecked-a")
+           (completions "unchecked-a" "cljs.core.async")
+           (completions "unchecked-a" {:context-ns "cljs.core.async"})))))


### PR DESCRIPTION
A simialar change was just merged to Compliment: alexander-yakushev/compliment/pull/26 and the plan is that cider-nrepl will have options to utilize this option if frontend (e.g. vim-fireplace) asks for it.

About the implementation:

I changed the third parameter of completions to take in a options map, but if the parameter is a string it works like before. I don't know if this is a good idea in the long run or would it be better to just break the API.

Enriching is done as a separate step after filtering, this means that in some cases additional work is done when find-var is used to find the metadata for var second time. If options-map was passed to `var-candidates` the response map could be build completely there. I'm not sure which option is the better for performance.


