### PR TITLE
ClojureScript 3196 support (breaks backwards compat)

### DIFF
--- a/src/cljs_tooling/complete.clj
+++ b/src/cljs_tooling/complete.clj
@@ -1,7 +1,8 @@
 (ns cljs-tooling.complete
   "Standalone auto-complete library based on cljs analyzer state"
   (:require [cljs-tooling.util.analysis :as a]
-            [cljs-tooling.util.misc :as u]))
+            [cljs-tooling.util.misc :as u]
+            [cljs-tooling.info :as i]))
 
 (defn- candidate-data
   "Returns a map of candidate data for the given arguments."
@@ -188,12 +189,12 @@
   [candidate prefix]
   (.startsWith ^String (:candidate candidate) (str prefix)))
 
-(defn- enrich-candidate [candidate env {:keys [extra-metadata]}]
+(defn- enrich-candidate [candidate env {:keys [context-ns extra-metadata]}]
   (if (seq extra-metadata)
-    (let [var-meta (a/find-var env (symbol (str (:ns candidate)) (:candidate candidate)))]
+    (let [var-meta (i/info env (symbol (str (:ns candidate)) (:candidate candidate)) context-ns)]
       (cond-> candidate
         (and (:arglists extra-metadata) (:arglists var-meta))
-        (assoc :arglists (apply list (map pr-str (eval (:arglists var-meta)))))
+        (assoc :arglists (apply list (map pr-str (:arglists var-meta))))
 
         (and (:doc extra-metadata) (:doc var-meta))
         (assoc :doc (:doc var-meta))))

--- a/test/cljs_tooling/test_complete.clj
+++ b/test/cljs_tooling/test_complete.clj
@@ -232,4 +232,8 @@
   (testing ":doc"
     (is (= '({:candidate "unchecked-add" :ns cljs.core :type :function :doc "Returns the sum of nums. (+) returns 0."}
              {:candidate "unchecked-add-int" :ns cljs.core :type :function :doc "Returns the sum of nums. (+) returns 0."})
-           (completions "unchecked-a" {:context-ns "cljs.core.async", :extra-metadata #{:doc}})))))
+           (completions "unchecked-a" {:context-ns "cljs.core.async", :extra-metadata #{:doc}}))))
+
+  (testing "macro metadata"
+    (is (= '({:candidate "defprotocol", :ns cljs.core, :type :macro, :arglists ("[psym & doc+methods]")})
+           (completions "defproto" {:context-ns "cljs.user", :extra-metadata #{:arglists}})))))


### PR DESCRIPTION
I hit some problems while I was testing intergration with cider-nrepl:
1. Find-var doesn't work for macro vars
2. `:arglists` is no longer "double quoted" in Cljs-3196 and thus eval causes exception

The first problem is fixed by using functions provided in [cljs.analyzer.api](https://github.com/clojure/clojurescript/blob/master/src/clj/cljs/analyzer/api.clj) instead of reading the env map directly.

What do you think about preserving backwards compatibility? It might be possible to support old versions but testing them would be quite painful.

Btw. this broke two tests with macro namespaces, I'm not sure if the problem is with tests or implementation.

---

- In previous Cljs versions arglists was double quoted which is why my previous commit read arglists using eval. Now trying to eval arglists causes exception.
- The previous version of find-var was unable to find data for macro vars. Now resolve-env from Cljs analyzer api is used. It can successfully resolve both normal and macro vars.
- Other low level utils in analysis ns have also been changed to use analyzer api.