### PR TITLE
Filter foreign protocols from completion candidates

### DIFF
--- a/src/cljs_tooling/complete.clj
+++ b/src/cljs_tooling/complete.clj
@@ -71,7 +71,7 @@
   [vars]
   (for [[name meta] vars
         :let [qualified-name (:name meta)
-              ns (namespace qualified-name)
+              ns (some-> qualified-name namespace)
               type (var->type meta)]]
     (candidate-data name ns type)))
 

--- a/src/cljs_tooling/info.clj
+++ b/src/cljs_tooling/info.clj
@@ -32,8 +32,8 @@
   "Format it similarly to metadata on a var"
   [context-ns var]
   (-> (select-keys var [:arglists :name :line :column :file :doc])
-      (merge {:name (-> var :name name u/as-sym)
-              :ns (-> var :name namespace u/as-sym)})
+      (merge {:name (some-> var :name name u/as-sym)
+              :ns (some-> var :name namespace u/as-sym)})
       (update-in [:arglists] unquote-1)))
 
 (defn format-macro

--- a/src/cljs_tooling/util/analysis.clj
+++ b/src/cljs_tooling/util/analysis.clj
@@ -75,12 +75,12 @@
   (get (macro-ns-aliases env ns) (u/as-sym sym)))
 
 (defn- public?
-  [var]
-  ((complement :private) (val var)))
+  [[_ var]]
+  (not (:private var)))
 
 (defn- named?
-  [var]
-  ((complement :anonymous) (val var)))
+  [[_ var]]
+  (not (:anonymous var)))
 
 (defn- foreign-protocol?
   [[_ var]]
@@ -88,10 +88,8 @@
        (not (:protocol-symbol var))))
 
 (defn- macro?
-  [var]
-  (-> (val var)
-      meta
-      :macro))
+  [[_ var]]
+  (:macro (meta var)))
 
 (defn ns-vars
   "Returns a list of the vars declared in the ns."

--- a/src/cljs_tooling/util/analysis.clj
+++ b/src/cljs_tooling/util/analysis.clj
@@ -82,6 +82,11 @@
   [var]
   ((complement :anonymous) (val var)))
 
+(defn- foreign-protocol?
+  [[_ var]]
+  (and (:impls var)
+       (not (:protocol-symbol var))))
+
 (defn- macro?
   [var]
   (-> (val var)
@@ -93,7 +98,7 @@
   [env ns]
   (->> (find-ns env ns)
        :defs
-       (filter named?)
+       (filter (every-pred named? (complement foreign-protocol?)))
        (into {})))
 
 (defn public-vars
@@ -101,7 +106,7 @@
   [env ns]
   (->> (find-ns env ns)
        :defs
-       (filter (every-pred named? public?))
+       (filter (every-pred named? public? (complement foreign-protocol?)))
        (into {})))
 
 (defn public-macros


### PR DESCRIPTION
If you have these two namespaces:

```clojure
(ns test-ns)

(defrecord TestRecord [a b c])

(defprotocol TestProtocol
  (test-method [_]))  
```

```clojure
(ns test-ns-2
  (:require [test-ns :as t :refer [TestProtocol]]))

(extend-protocol TestProtocol
  t/TestRecord
  (test-method [_]))
```

Then `test-ns-2/TestProtocol` is returned as a completion candidate, which causes `var-candidates` to throw an exception - the (rather large) stacktrace is unfortunately printed to the REPL every time the complete op is called if the completion prefix is `test-ns-2`. `format-var` also throws when calling the info op on the candidate.

The root cause is possibly a bug in the cljs analyzer - the protocol has an entry in `:defs` in the _extending_ namespace with incomplete metadata, but only when it's referred directly - we should still filter it regardless of if this changes in a future version of cljs.